### PR TITLE
新規グループの作成時のエラーを解決

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -29,7 +29,7 @@ class GroupsController < ApplicationController
   private
 
   def group_params
-    params.require(:group).permit(:name, user_ids: [] )
+    params.require(:group).permit(:name, {user_ids: []} )
   end
 
   def set_group

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,7 +3,7 @@ class Group < ApplicationRecord
   has_many :messages
   has_many :users, through: :group_users
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
   def show_last_message
     if (last_message = messages.last).present?


### PR DESCRIPTION
# What
新規グループの作成時のエラーを解決

# Why
既存のグループと同じ名前のグループを作成しても、エラーが出ないようにするため